### PR TITLE
Change withdrawal credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ release
 
 # Default data output dirs
 deposit-data*
+bls-to-execution-change*
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lattice-cli",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lattice-cli",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^16.0.0",
         "enquirer": "^2.3.6",
         "gridplus-sdk": "^2.4.1",
-        "lattice-eth2-utils": "^0.4.3",
+        "lattice-eth2-utils": "^0.5.1",
         "spinnies": "^0.5.1",
         "ts-node": "^10.7.0"
       },
@@ -3903,9 +3903,9 @@
       }
     },
     "node_modules/lattice-eth2-utils": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/lattice-eth2-utils/-/lattice-eth2-utils-0.4.3.tgz",
-      "integrity": "sha512-LioMZMPCevjN7ST8MuUtxs0m/2DRw+BztZJUjn77qW011ts9pzp5+vuzLsybyM9Xkafu+HtNsEJqdc+VJjGAsQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/lattice-eth2-utils/-/lattice-eth2-utils-0.5.1.tgz",
+      "integrity": "sha512-S1VeykS8K9bBeQ0S+OXEdmq7myR21hy0CidO83Uaydo7g1a9LTjK2ScVK3nuY11/3nCzS5i9DrLGW36vE38Zmg==",
       "dependencies": {
         "@chainsafe/ssz": "^0.9.2",
         "@ethersproject/abi": "^5.7.0",
@@ -8344,9 +8344,9 @@
       "dev": true
     },
     "lattice-eth2-utils": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/lattice-eth2-utils/-/lattice-eth2-utils-0.4.3.tgz",
-      "integrity": "sha512-LioMZMPCevjN7ST8MuUtxs0m/2DRw+BztZJUjn77qW011ts9pzp5+vuzLsybyM9Xkafu+HtNsEJqdc+VJjGAsQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/lattice-eth2-utils/-/lattice-eth2-utils-0.5.1.tgz",
+      "integrity": "sha512-S1VeykS8K9bBeQ0S+OXEdmq7myR21hy0CidO83Uaydo7g1a9LTjK2ScVK3nuY11/3nCzS5i9DrLGW36vE38Zmg==",
       "requires": {
         "@chainsafe/ssz": "^0.9.2",
         "@ethersproject/abi": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lattice-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI for interacting with gridplus-sdk",
   "main": "./dist/lattice-cli.js",
   "types": "./dist/lattice-cli.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lattice-cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CLI for interacting with gridplus-sdk",
   "main": "./dist/lattice-cli.js",
   "types": "./dist/lattice-cli.d.ts",
@@ -19,7 +19,7 @@
     "dotenv": "^16.0.0",
     "enquirer": "^2.3.6",
     "gridplus-sdk": "^2.4.1",
-    "lattice-eth2-utils": "^0.4.3",
+    "lattice-eth2-utils": "^0.5.1",
     "spinnies": "^0.5.1",
     "ts-node": "^10.7.0"
   },

--- a/src/commands/buildDepositData.ts
+++ b/src/commands/buildDepositData.ts
@@ -1,11 +1,5 @@
 import { AbiCoder } from '@ethersproject/abi';
 import { 
-  chmodSync,
-  existsSync, 
-  mkdirSync, 
-  writeFileSync, 
-} from 'fs';
-import { 
   Client, 
   Constants as SDKConstants 
 } from "gridplus-sdk";
@@ -32,6 +26,7 @@ import {
   pathIntToStr, 
   pathStrToInt, 
   printColor,
+  saveFile,
   startNewSpinner
 } from '../utils';
 
@@ -230,20 +225,21 @@ export async function cmdGenDepositData(client: Client) {
     "Where do you wish to save the deposit data files? ",
     "./deposit-data"
   );
-  if (!existsSync(fDir)) {
-    mkdirSync(fDir);
-  }
   for (let i = 0; i < depositData.length; i++) {
-    const fPath = fDir + `/keystore-m_12381_3600_${startingIdx + i}_0_0-${datetime}.json`;
-    writeFileSync(fPath, keystores[i]);
-    // These are JSON files so they don't really need to be executable,
-    // but this matches the permissions from the official Ethereum Deposit CLI.
-    chmodSync(fPath, "710");
+    saveFile(
+      fDir, 
+      `keystore-m_12381_3600_${startingIdx + i}_0_0-${datetime}.json`,
+      keystores[i], 
+      // NOTE: These are JSON files so they don't really need to be executable,
+      // but this matches the permissions from the official Ethereum Deposit CLI.
+      "710"
+    );
   };
-  const fName = exportCalldata ?
-                `deposit-calldata-${datetime}.json` :
-                `deposit-data-${datetime}.json`;
-  writeFileSync(fDir + '/' + fName, JSON.stringify(depositData));
+  saveFile(
+    fDir, 
+    exportCalldata ? `deposit-calldata-${datetime}.json` : `deposit-data-${datetime}.json`,
+    JSON.stringify(depositData)
+  );
   printColor(`Validator deposit data files saved to ${fDir}`, "green");
 }
 

--- a/src/commands/changeBLSCredentials.ts
+++ b/src/commands/changeBLSCredentials.ts
@@ -41,14 +41,17 @@ export async function cmdChangeBLSCredentials(client: Client) {
     return;
   }
   console.log('');
-  const startIdx = await promptForNumber(
-    "What is the starting derivation index of the validator(s) you wish to change? ",
-    0,
-  );
   const useDefaultPaths = await promptForBool(
-    "Did you use the default BLS withdrawal path to generate your withdrawal credentials? ",
+    "Are these validators derived from the default path (EIP2334) and are they sequential?",
     true
   );
+  let startIdx = 0;
+  if (useDefaultPaths) {
+    startIdx = await promptForNumber(
+      "What is the derivation index of the first validator(s) you wish to change? ",
+      0,
+    );
+  }
   let eth1Addr = await promptForString(
     "Please enter the ETH1 address you wish to use for your new withdrawal credentials: ",
     "0x"
@@ -173,8 +176,8 @@ export async function cmdChangeBLSCredentials(client: Client) {
       `and run the following command:\n` +
       `\n-----------------------\n` +
       `curl -d @${fName} -H "Content-Type: application/json" -X POST 127.0.0.1:4000/eth/v1/beacon/pool/bls_to_execution_changes` +
-      `\n-----------------------\n\n`,
-      `For more details, please see this guide: https://notes.ethereum.org/@launchpad/withdrawals-guide`
+      `\n-----------------------\n\n` +
+      `For more details, please see this guide: https://notes.ethereum.org/@launchpad/withdrawals-guide`,
       'green'
     );
   }

--- a/src/commands/changeBLSCredentials.ts
+++ b/src/commands/changeBLSCredentials.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from 'fs';
 import { sha256 } from '@noble/hashes/sha256';
 import {
   Client,
@@ -18,6 +17,7 @@ import {
   isValidEth1Addr,
   pathStrToInt,
   printColor,
+  saveFile,
   startNewSpinner,
 } from '../utils';
 
@@ -161,23 +161,28 @@ export async function cmdChangeBLSCredentials(client: Client) {
   }
 
   if (signedMsgs.length > 0) {
+    const fDir = await promptForString(
+      "Where do you wish to save the deposit data files? ",
+      "./bls-to-execution-change"
+    );
     // Write the file
     const fName = `bls_to_execution_change-${Date.now()}.json`;
-    writeFileSync(fName, JSON.stringify(signedMsgs));
+    saveFile(
+      fDir,
+      fName,
+      JSON.stringify(signedMsgs),
+      // NOTE: These are JSON files so they don't really need to be executable,
+      // but this matches the permissions from the official Ethereum Deposit CLI.
+      "710"
+    )
     // Tell the user how to use it
     printColor(
       `\n\n` +
       `=======================\n` +
       `Generated credential change data for ${signedMsgs.length} validators ` +
       `(${validatorIndices.join(', ')})\n` +
-      `Wrote to file: ${fName}\n` +
-      `=======================\n` +
-      `Please move this file to the machine running your consensus client ` +
-      `and run the following command:\n` +
-      `\n-----------------------\n` +
-      `curl -d @${fName} -H "Content-Type: application/json" -X POST 127.0.0.1:4000/eth/v1/beacon/pool/bls_to_execution_changes` +
-      `\n-----------------------\n\n` +
-      `For more details, please see this guide: https://notes.ethereum.org/@launchpad/withdrawals-guide`,
+      `Wrote to file: ${fDir + '/' + fName}\n` +
+      `=======================\n`,
       'green'
     );
   }

--- a/src/commands/changeBLSCredentials.ts
+++ b/src/commands/changeBLSCredentials.ts
@@ -1,0 +1,169 @@
+import { sha256 } from '@noble/hashes/sha256';
+import {
+  Client,
+  Constants as SDKConstants,
+} from 'gridplus-sdk';
+import { 
+  BLSToExecutionChange, 
+  Constants as ETH2Constants 
+} from 'lattice-eth2-utils';
+import {
+  promptForBool,
+  promptForNumber,
+  promptForString,
+} from '../prompts';
+import {
+  isValidEth1Addr,
+  pathStrToInt,
+  printColor,
+} from '../utils';
+
+/**
+ * Construct a series of signed messages which will update ETH validators' credentials
+ * from the original BLS variety (0x00) to the new ETH1 variety (0x01).
+ * This can only happen *once* per validator.
+ * The original 0x00 credentials use BLS keys for withdrawal credentials, but the ETH
+ * execution layer can only send funds to ETH1 addresses (secp256k1-derived) and not
+ * ETH2 addresses (bls12_381-derived). Thus, legacy withdrawal credentials must be changed.
+ */
+export async function cmdChangeBLSCredentials(client: Client) {
+  const shouldContinue = await promptForBool(
+    "This method will change the withdrawal credentials for your validator(s). This can " +
+    "only be done once per validator, so please use this tool carefully!\n\n" +
+    "Do you currently have BLS (type 0) withdrawal credentials for the validator(s) you wish to change? ",
+    true);
+  if (!shouldContinue) {
+    printColor("Only BLS (type 0) withdrawal credentials can be changed. Exiting.", "yellow");
+    return;
+  }
+  const startingIdx = await promptForNumber(
+    "What is the starting derivation index of the validator(s) you wish to change? ",
+    0,
+  );
+  const useDefaultPaths = await promptForBool(
+    "Did you use the default BLS withdrawal path to generate your withdrawal credentials? ",
+    true
+  );
+  let eth1Addr = await promptForString(
+    "Please enter the ETH1 address you wish to use for your new withdrawal credentials: ",
+    "0x"
+  );
+  eth1Addr = eth1Addr.toLowerCase();
+  if (!isValidEth1Addr(eth1Addr)) {
+    printColor("Invalid ETH1 address.", "red");
+    return;
+  }
+  
+  // Track state variables
+  let count = 0;
+  let signedMsgs = [];
+
+  // Loop through each validator and generate a signed message
+  while (true) {
+    let withdrawalPathStr = getDefaultBLSWithdrawalPathStr(startIdx + count);
+    let validatorPathStr = getDefaultBLSValidatorPathStr(startIdx + count);
+    if (!useDefaultPaths) {
+      withdrawalPathStr = await promptForString(
+        `What derivation path was used for validator #${startIdx + count}'s withdrawal credentials? `,
+        withdrawalPathStr
+      );
+      validatorPathStr = await promptForString(
+        `What derivation path was used to generate validator #${startIdx + count}'s deposit data? `,
+        validatorPathStr
+      );
+    }
+    const validatorPub = await getBLSPubkey(client, pathStrToInt(validatorPathStr));
+    const validatorIdx = await promptForNumber(
+      "Please visit the following link, confirm the validator belongs to you, and enter the " +
+      "numerical validator index.\n" +
+      `https://beaconcha.in/validator/${validatorPub}\n`,
+      0
+    );
+    
+    const withdrawalPub = await getBLSPubkey(client, pathStrToInt(withdrawalPathStr));
+    const blsCreds = getBLSWithdrawalCredentials(withdrawalPub);
+    const confirmChange = await promptForBool(
+      `Changing credentials for validator #${validatorIdx} (${validatorPub}):\n` +
+      `Old withdrawal address: ${withdrawalPub}\n` +
+      `Old withdrawal credentials: 0x${blsCreds}\n` +
+      `New withdrawal address: ${eth1Addr}\n\n` +
+      `Do you wish to make this change?`
+      true
+    );
+    if (!confirmChange) {
+      break;
+    }
+
+    const signedMsg = await BLSToExecutionChange.generateObject(
+      globals.client,
+      pathStrToInt(withdrawalPathStr),
+      { eth1Addr, validatorIdx }
+    );
+    signedMsgs.push(signedMsg);
+    count++;
+
+    const nextOne = await promptForBool(
+      `Do you want to change credentials for the next validator (derivation index #${startIdx + count})? `,
+      true
+    );
+    if (!nextOne) {
+      printColor(
+        `\n\n` +
+        `=======================\n` +
+        `Please send the following message to your consensus client or credential change service:\n` +
+        `${JSON.stringify(signedMsgs)}\n` +
+        `=======================\n` +
+      );
+      return;
+    }
+  }
+}
+
+/**
+ * @internal
+ * Get the default BLS withdrawal key's path, as per EIP2334:
+ * https://eips.ethereum.org/EIPS/eip-2334
+ * @return {string} The BIP39 derivation path
+*/
+function getDefaultBLSWithdrawalPathStr(idx: number): string {
+  return `m/12381/3600/${idx}/0`;
+}
+
+/**
+ * @internal
+ * Get the default BLS validator key's path, as per EIP2334:
+ * https://eips.ethereum.org/EIPS/eip-2334
+ * @return {string} The BIP39 derivation path
+*/
+function getDefaultBLSValidatorPathStr(idx: number): string {
+  return getDefaultBLSWithdrawalPathStr(idx) + "/0";
+}
+
+/**
+ * @internal
+ * Get the BLS public key associated with a deposit BIP39 path.
+ * @return {string} The BLS public key as a hex string (no 0x prefix).
+ */
+async function getBLSPubkey(client: Client, path: number[]): Promise<string> {
+  const pubkeys = await client.getAddresses({
+    // BLS withdrawal key path, by standard, is one derivation index
+    // shorter than the deposit path, but with the same path otherwise.
+    startPath: path
+    n: 1,
+    flag: SDKConstants.GET_ADDR_FLAGS.BLS12_381_G1_PUB,
+  });
+  return pubkeys[0].toString('hex');
+}
+
+/**
+ * Return the original 0x00 type BLS withdrawal credentials given a path.
+ * @return {string} The withdrawal credentials as a hex string (no 0x prefix).
+ */
+function getBLSWithdrawalCredentials(blsWithdrawalPub: string): Promise<string>{
+  const creds = Buffer.alloc(32);
+  creds[0] = 0;
+  Buffer.from(
+    sha256(Buffer.from(blsWithdrawalPub, 'hex'))
+  ).slice(1).copy(creds, 1);
+  return creds.toString('hex');
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,4 @@
 export * from './buildDepositData';
+export * from './changeBLSCredentials';
 export * from './getAddress';
 export * from './getPubkey';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,6 +50,7 @@ Once connected to your device, you can interact with its active wallet to:\n\
 - Request formatted (Ethereum or Bitcoin) addresses\n\
 - Request public keys\n\
 - Generate validator deposit data\n\
+- Change validator withdrawal credentials\n\
 `
 const WARNING_MSG =
 `\

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,9 @@
 const COMMANDS = {
+  CHANGE_BLS_WITHDRAWAL_CREDS: 'Change Validator Withdrawal Credentials',
   EXIT: 'Exit',
+  EXPORT_DEPOSIT_DATA: 'Export Validator Deposit Data',
   GET_ADDRESS: 'Get Address',
   GET_PUBLIC_KEY: 'Get Public Key',
-  EXPORT_DEPOSIT_DATA: 'Export ETH2 Deposit Data',
 };
 
 const DEFAULT_PATHS = {

--- a/src/lattice-cli.ts
+++ b/src/lattice-cli.ts
@@ -54,8 +54,6 @@ import {
       continue;
     } else if (creds.password.length < 6) {
       printColor("Password must be at least 6 characters.", "red");
-    } else if (creds.url.indexOf("https://") < 0) {
-      printColor("URL must start with 'https://'.", "red");
     }
 
     // Instantiate the SDK client
@@ -196,10 +194,6 @@ async function getUrl(useEnv: boolean): Promise<string> {
     url = process.env.LATTICE_CONNECT_URL;
   } else {
     url = await promptForString("Enter Connection URL: ", DEFAULT_URL);
-  }
-  if (url.indexOf("https://") !== 0) {
-    printColor("URL must start with 'https://'", "red");
-    return await getUrl(useEnv);
   }
   return url;
 }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -2,7 +2,12 @@
 import { AutoComplete, NumberPrompt, Toggle, prompt } from "enquirer";
 import { Client } from "gridplus-sdk";
 import { COMMANDS, PUBKEY_TYPES } from './constants';
-import { cmdGenDepositData, cmdGetAddresses, cmdGetPubkeys } from "./commands";
+import { 
+  cmdChangeBLSCredentials,
+  cmdGenDepositData, 
+  cmdGetAddresses, 
+  cmdGetPubkeys 
+} from "./commands";
 import { clearPrintedLines } from "./utils";
 
 export const promptForBool = async (message: string, defaultTrue=true) => {
@@ -72,6 +77,9 @@ export const promptForCommand = async (client: Client) => {
         break;
       case COMMANDS.EXPORT_DEPOSIT_DATA:
         await cmdGenDepositData(client);
+        break;
+      case COMMANDS.CHANGE_BLS_WITHDRAWAL_CREDS:
+        await cmdChangeBLSCredentials(client);
         break;
       case COMMANDS.EXIT:
         process.exit(0);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -61,6 +61,7 @@ export const promptForCommand = async (client: Client) => {
     initial: 0,
     choices: [
       COMMANDS.EXPORT_DEPOSIT_DATA,
+      COMMANDS.CHANGE_BLS_WITHDRAWAL_CREDS,
       COMMANDS.GET_ADDRESS,
       COMMANDS.GET_PUBLIC_KEY,
       COMMANDS.EXIT,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,10 @@
 import crypto from "crypto";
+import { 
+  chmodSync,
+  existsSync, 
+  mkdirSync, 
+  writeFileSync, 
+} from 'fs';
 import Spinnies from "spinnies";
 let spinner: Spinnies;
 
@@ -124,4 +130,19 @@ export function getDecimalPlaces(num: number): number {
   const str = num.toString();
   const decimalIndex = str.indexOf('.');
   return decimalIndex === -1 ? 0 : str.length - decimalIndex - 1;
+}
+
+/**
+ * Save a file to a directory with optional permissions.
+ * Create the directory if it doesn't exist.
+ */
+export function saveFile(fDir: string, fName: string, data: string, perm?: string) {
+  if (!existsSync(fDir)) {
+    mkdirSync(fDir);
+  }
+  const path = fDir + '/' + fName;
+  writeFileSync(path, data);
+  if (perm) {
+    chmodSync(path, perm);
+  }
 }


### PR DESCRIPTION
This adds a user flow for changing ETH2 withdrawal credentials from native BLS (type `0x00`) to ETH1 (type `0x01`). It wraps the functionality in https://github.com/GridPlus/lattice-eth2-utils/pull/4.

The user flow should be similar to that of generating deposit data.

Docs also added.

Closes #3